### PR TITLE
Rack 2.x better versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,12 @@ rvm:
 gemfile:
   - Gemfile
   - test/gemfiles/rack-1.x-gemfile
-  - test/gemfiles/minimum_versions
+  - test/gemfiles/2.3-and-up-minimum_versions
 
 matrix:
   include:
+    - rvm: 2.2.6
+      gemfile: test/gemfiles/minimum_versions
     - rvm: 2.1.6
       gemfile: test/gemfiles/rack-1.x-gemfile
     - rvm: 2.1.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,25 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.2.2
-  - 2.1.6
-  - 1.9.3
+  - 2.4.0
+  - 2.3.3
+  - 2.2.6
 
 gemfile:
   - Gemfile
+  - test/gemfiles/rack-1.x-gemfile
   - test/gemfiles/minimum_versions
 
 matrix:
   include:
+    - rvm: 2.1.6
+      gemfile: test/gemfiles/rack-1.x-gemfile
+    - rvm: 2.1.6
+      gemfile: test/gemfiles/minimum_versions
+    - rvm: 1.9.3
+      gemfile: test/gemfiles/rack-1.x-gemfile
+    - rvm: 1.9.3
+      gemfile: test/gemfiles/minimum_versions
     - rvm: 1.8.7
       gemfile: test/gemfiles/1.8.7-compatible
     - rvm: 1.8.7

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'rack', '~> 1.4', :platforms => [:ruby_19, :ruby_21]
-# 2.6.4 breaks ruby 1.9 support because it requires mime-types 3+
-# which requires ruby > 2.
-# See https://github.com/mikel/mail/issues/990 for details
-#
-# This has been fixed in current master but not released yet.
-# See https://github.com/mikel/mail/commit/0277b8ee3204a3971fdfd6d92fd65ef80e9e9879
-gem 'mail', '<= 2.6.3', :platforms => :ruby_19

--- a/rack-contrib.gemspec
+++ b/rack-contrib.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   # REMINDER: If you modify any dependencies, please ensure you
   # update `test/gemfiles/minimum_versions`!
   #
-  s.add_runtime_dependency 'rack', '>= 1.4'
+  s.add_runtime_dependency 'rack', '>= 1.4', '< 3.0'
   s.add_runtime_dependency 'git-version-bump', '~> 0.15'
 
   s.add_development_dependency 'bundler', '~> 1.0'

--- a/test/gemfiles/2.3-and-up-minimum_versions
+++ b/test/gemfiles/2.3-and-up-minimum_versions
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+# These are the minimum available versions of all the gems we need, based on
+# the version specs in the gemspec.  We test against all of these to ensure
+# we haven't accidentally used a feature of a gem that isn't in the oldest
+# version we say we need.
+#
+gem 'rack',                '= 1.4.0'
+gem 'git-version-bump',    '= 0.15.0'
+gem 'i18n',                '= 0.4.0'
+gem 'json',                '= 1.8.5'
+gem 'minitest',            '= 5.6.0'
+gem 'minitest-hooks',      '= 1.0.0'
+gem 'mail',                '= 2.3.0'
+gem 'nbio-csshttprequest', '= 1.0.2'
+gem 'rdoc',                '= 3.12'
+gem 'rake',                '= 10.4.2'
+gem 'ruby-prof',           '= 0.13.0'

--- a/test/gemfiles/rack-1.x-gemfile
+++ b/test/gemfiles/rack-1.x-gemfile
@@ -1,0 +1,21 @@
+source 'https://rubygems.org'
+
+gem 'git-version-bump', '~> 0.15'
+gem 'github-release', '~> 0.1'
+gem 'i18n', '~> 0.4'
+gem 'json', '~> 1.8'
+gem 'minitest', '~> 5.6'
+gem 'minitest-hooks', '~> 1.0'
+gem 'nbio-csshttprequest', '~> 1.0'
+gem 'rake', '~> 10.4', '>= 10.4.2'
+gem 'rdoc', '~> 3.12'
+gem 'ruby-prof', '~> 0.13.0'
+
+gem 'rack', '~> 1.4'
+# 2.6.4 breaks ruby 1.9 support because it requires mime-types 3+
+# which requires ruby > 2.
+# See https://github.com/mikel/mail/issues/990 for details
+#
+# This has been fixed in current master but not released yet.
+# See https://github.com/mikel/mail/commit/0277b8ee3204a3971fdfd6d92fd65ef80e9e9879
+gem 'mail', '~> 2.3', '<= 2.6.3', :platforms => :ruby_19

--- a/test/spec_rack_profiler.rb
+++ b/test/spec_rack_profiler.rb
@@ -5,7 +5,10 @@ begin
   require 'rack/contrib/profiler'
 
   describe 'Rack::Profiler' do
-    app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, 'Oh hai der'] }
+    app = lambda do |env|
+      sleep 0.1
+      [200, {'Content-Type' => 'text/plain'}, 'Oh hai der']
+    end
     request = Rack::MockRequest.env_for("/", :params => "profile=process_time")
 
     specify 'printer defaults to RubyProf::CallStackPrinter' do
@@ -17,7 +20,7 @@ begin
     specify 'called multiple times via query params' do
       req = Rack::MockRequest.env_for("/", :params => "profile=process_time&profiler_runs=4")
       body = Rack::Profiler.new(app).call(req)[2].string
-      body.must_match(/Proc#call \[4 calls, 4 total\]/)
+      body.must_match(/Kernel#sleep \[4 calls, 4 total\]/)
     end
 
     specify 'CallStackPrinter has Content-Type test/html' do


### PR DESCRIPTION
Hi,

Nice branch you have here that works with rack 2.x :) This PR basically makes the versioning and travis config nicer.

The main idea is:
- To limit rack support with 1.x and 2.x (since we don't know whether it's going to be compatible)
- Test against rack 2.x and 1.x (created an explicit gemfile for 1.x support)
- Add ruby 2.4 and 2.3 in the rotation.

I aimed to the broadest possible compatibility, but of course some old versions should be dropped (since they're EOLed), but that's not up to me to decide.

I think with these changes it has better chances to be accepted to the mainstream (once maintainers are awoke from the winter hibernation).

I tweaked it so it passes specs (https://travis-ci.org/libc/rack-contrib/builds/206734775). If you have any suggestions do not hesitate to make them, I can change the code.

Cheers 